### PR TITLE
Use the exception log arg to log exception

### DIFF
--- a/src/citations.jl
+++ b/src/citations.jl
@@ -12,8 +12,7 @@ function get_citation(pkg)
         try
             import_bibtex(bib_path)
         catch e
-            @warn("There was an error reading the CITATION.bib file for $(pkg.name)")
-            @debug e
+            @warn("There was an error reading the CITATION.bib file for $(pkg.name)" exception=e)
         end
     end
 end

--- a/src/citations.jl
+++ b/src/citations.jl
@@ -12,7 +12,7 @@ function get_citation(pkg)
         try
             import_bibtex(bib_path)
         catch e
-            @warn("There was an error reading the CITATION.bib file for $(pkg.name)" exception=e)
+            @warn "There was an error reading the CITATION.bib file for $(pkg.name)" exception=e
         end
     end
 end


### PR DESCRIPTION
The ConsoleLogger (and probably others) have special handling for log arguments called `exception`.
(Can also pass backtrace there but that is probably too spammy).

using `@debug` for this just seems annoying. If there is an error I want to know what it is.
Making me remember how to enable debug loading and then rerun is just annoying
